### PR TITLE
Skip normalization if sum_squares is already close to 1

### DIFF
--- a/bindings/nodejs/src/core/src/distance.c
+++ b/bindings/nodejs/src/core/src/distance.c
@@ -253,14 +253,8 @@ void normalize_vector(float *arr, uint32_t length)
         sum_squares += arr[i] * arr[i];
     }
 
-    // If the array is all zeros or very close to zero, avoid division by zero
-    if (sum_squares < 1e-10)
-    {
-        return;
-    }
-
-    // If the array is already normalized within a small tolerance, skip normalization
-    if (sum_squares > 0.99995f && sum_squares < 1.00005f)
+    // If sum_squares is close to 0 or 1 (already normalized), skip normalization
+    if (sum_squares < 1e-10 || (sum_squares > 0.99995f && sum_squares < 1.00005f))
     {
         return;
     }

--- a/bindings/nodejs/src/core/src/distance.c
+++ b/bindings/nodejs/src/core/src/distance.c
@@ -259,6 +259,12 @@ void normalize_vector(float *arr, uint32_t length)
         return;
     }
 
+    // If the array is already normalized within a small tolerance, skip normalization
+    if (sum_squares > 0.99995f && sum_squares < 1.00005f)
+    {
+        return;
+    }
+
     // Calculate the normalization factor (1/sqrt(sum_squares))
     float norm_factor = 1.0f / sqrtf(sum_squares);
 

--- a/bindings/python/src/core/src/distance.c
+++ b/bindings/python/src/core/src/distance.c
@@ -253,14 +253,8 @@ void normalize_vector(float *arr, uint32_t length)
         sum_squares += arr[i] * arr[i];
     }
 
-    // If the array is all zeros or very close to zero, avoid division by zero
-    if (sum_squares < 1e-10)
-    {
-        return;
-    }
-
-    // If the array is already normalized within a small tolerance, skip normalization
-    if (sum_squares > 0.99995f && sum_squares < 1.00005f)
+    // If sum_squares is close to 0 or 1 (already normalized), skip normalization
+    if (sum_squares < 1e-10 || (sum_squares > 0.99995f && sum_squares < 1.00005f))
     {
         return;
     }

--- a/bindings/python/src/core/src/distance.c
+++ b/bindings/python/src/core/src/distance.c
@@ -259,6 +259,12 @@ void normalize_vector(float *arr, uint32_t length)
         return;
     }
 
+    // If the array is already normalized within a small tolerance, skip normalization
+    if (sum_squares > 0.99995f && sum_squares < 1.00005f)
+    {
+        return;
+    }
+
     // Calculate the normalization factor (1/sqrt(sum_squares))
     float norm_factor = 1.0f / sqrtf(sum_squares);
 

--- a/src/core/src/distance.c
+++ b/src/core/src/distance.c
@@ -253,14 +253,8 @@ void normalize_vector(float *arr, uint32_t length)
         sum_squares += arr[i] * arr[i];
     }
 
-    // If the array is all zeros or very close to zero, avoid division by zero
-    if (sum_squares < 1e-10)
-    {
-        return;
-    }
-
-    // If the array is already normalized within a small tolerance, skip normalization
-    if (sum_squares > 0.99995f && sum_squares < 1.00005f)
+    // If sum_squares is close to 0 or 1 (already normalized), skip normalization
+    if (sum_squares < 1e-10 || (sum_squares > 0.99995f && sum_squares < 1.00005f))
     {
         return;
     }

--- a/src/core/src/distance.c
+++ b/src/core/src/distance.c
@@ -259,6 +259,12 @@ void normalize_vector(float *arr, uint32_t length)
         return;
     }
 
+    // If the array is already normalized within a small tolerance, skip normalization
+    if (sum_squares > 0.99995f && sum_squares < 1.00005f)
+    {
+        return;
+    }
+
     // Calculate the normalization factor (1/sqrt(sum_squares))
     float norm_factor = 1.0f / sqrtf(sum_squares);
 


### PR DESCRIPTION
In normalize_vector, if the array is already normalized within a small tolerance, skip normalization.